### PR TITLE
fix: Bump version due to manifest update

### DIFF
--- a/HarderFeatherFallMod.cs
+++ b/HarderFeatherFallMod.cs
@@ -13,7 +13,7 @@ namespace ValheimMovementMods
     {
         const string pluginGUID = "afilbert.ValheimHarderFeatherFallMod";
         const string pluginName = "Valheim - Harder Feather Fall Mod";
-        const string pluginVersion = "0.1.0";
+        const string pluginVersion = "0.1.1";
         public static ManualLogSource logger;
 
         private readonly Harmony _harmony = new Harmony(pluginGUID);

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **_Works with Mistlands Update!_**
 
-Have you ever thought the Feather Cape seemed too OP? Especially outside of the Mistlands biome? Me too. That's why I made this mod. Feather Cape now draws its power from Wisplight. When equipped together, the Feather Fall effects work normally. Otherwise, your fall speed and fall damage protection are proportionally bound to your available stamina. Each becomes more perilous the less stamina you have. Where 100% stamina will provide the expected fall speed and damage reduction benefits, 0% stamina feels like the cape isn't even equipped when falling... or landing.
+Have you ever thought the Feather Cape seemed too OP? Especially outside of the Mistlands biome? Me too. That's why I made this mod. Feather Cape now draws its power from Wisplight. When equipped together, the Feather Fall effects work normally. Otherwise, your fall speed and fall damage protection are proportionally bound to your available stamina. Each becomes more perilous the less stamina you have. Where 100% stamina will provide the expected fall speed and damage reduction benefits, 0% stamina feels like the cape isn't even equipped when falling... or landing. 
 
 Users of this mod beware. This is not a QOL improvement, it seeks to reduce the power of the Feather Cape outside of normal Mistlands play.
 
@@ -28,4 +28,5 @@ Built with [BepInEx](https://valheim.thunderstore.io/package/denikson/BepInExPac
 
 Releases in github repo are packaged for Thunderstore Mod Manager.
 
+* 0.1.1 Fix Thunderstore manifest `website_url`
 * 0.1.0 Initial publication


### PR DESCRIPTION
For Thunderstore. Copy/paste featured the wrong website_url